### PR TITLE
chore: upgrade ecstatic to suppress dependabot alert

### DIFF
--- a/example/shoe/package.json
+++ b/example/shoe/package.json
@@ -3,7 +3,7 @@
     "version" : "0.0.0",
     "dependencies" : {
         "shoe" : "~0.0.0",
-        "ecstatic" : "~0.1.6",
+        "ecstatic" : "~4.1.3",
         "domready" : "~0.2.11",
         "browserify" : "~1.12.3"
     },


### PR DESCRIPTION
The dependabot alert is due to outdated dependencies in an example project, and does not impact the `dnode` package.